### PR TITLE
Fix(Task): Load Tasks In Sub-directories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "adonis-scheduler",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2047,6 +2047,7 @@
           "version": "0.1.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -3229,7 +3230,8 @@
         "longest": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "loose-envify": {
           "version": "1.3.1",

--- a/src/Scheduler/index.js
+++ b/src/Scheduler/index.js
@@ -101,7 +101,7 @@ class Scheduler {
     let taskFiles
 
     try {
-      taskFiles = fs.readdirSync(this.tasksPath)
+      taskFiles = this._getFiles(this.tasksPath)
     } catch (e) {
       // If the directory isn't found, log a message and exit gracefully
       if (e.code === 'ENOENT') {
@@ -112,12 +112,29 @@ class Scheduler {
     }
 
     taskFiles = taskFiles.filter(file => path.extname(file) === '.js')
-
     for (let taskFile of taskFiles) {
       await this._fetchTask(taskFile)
     }
 
     debug('scheduler running %d tasks', this.registeredTasks.length)
+  }
+
+  _getFiles(directory, relativePath = "") {
+    let result = [];
+    
+    for (const file of fs.readdirSync(directory)) {
+      const fullPath = path.join(directory, file);
+      const relativeFile = path.join(relativePath, file)
+      
+      if (fs.statSync(fullPath).isDirectory()) {
+        result.push(...this._getFiles(fullPath, relativeFile));
+        continue;
+      }
+
+      result.push(relativeFile);
+    }
+
+    return result;
   }
 }
 

--- a/src/Scheduler/index.js
+++ b/src/Scheduler/index.js
@@ -119,19 +119,26 @@ class Scheduler {
     debug('scheduler running %d tasks', this.registeredTasks.length)
   }
 
-  _getFiles(directory, relativePath = "") {
+  /**
+   * Get all files in the `Task` directory.
+   * 
+   * @param {String} directory 
+   * @param {String} relativeDir 
+   * @private
+   */
+  _getFiles(directory, relativeDir = "") {
     let result = [];
     
     for (const file of fs.readdirSync(directory)) {
       const fullPath = path.join(directory, file);
-      const relativeFile = path.join(relativePath, file)
+      const relativePath = path.join(relativeDir, file)
       
       if (fs.statSync(fullPath).isDirectory()) {
-        result.push(...this._getFiles(fullPath, relativeFile));
+        result.push(...this._getFiles(fullPath, relativePath));
         continue;
       }
 
-      result.push(relativeFile);
+      result.push(relativePath);
     }
 
     return result;

--- a/test/projects/good/app/Tasks/a/Good.js
+++ b/test/projects/good/app/Tasks/a/Good.js
@@ -1,0 +1,14 @@
+'use strict'
+
+const Task = use('Task')
+
+class Good extends Task {
+  static get schedule () {
+    return '*/1 * * * * *'
+  }
+
+  async handle () {
+  }
+}
+
+module.exports = Good

--- a/test/projects/good/app/Tasks/a/b/Working.js
+++ b/test/projects/good/app/Tasks/a/b/Working.js
@@ -1,0 +1,14 @@
+'use strict'
+
+const Task = use('Task')
+
+class Working extends Task {
+  static get schedule () {
+    return '*/1 * * * * *'
+  }
+
+  async handle () {
+  }
+}
+
+module.exports = Working

--- a/test/scheduler.spec.js
+++ b/test/scheduler.spec.js
@@ -33,7 +33,7 @@ test.group('Scheduler', (group) => {
     const scheduler = new Scheduler(Helpers)
     await scheduler.run()
     assert.isArray(scheduler.registeredTasks)
-    assert.equal(scheduler.registeredTasks.length, 1)
+    assert.equal(scheduler.registeredTasks.length, 3)
   })
 
   test('Should ignore invalid task file types', async (assert) => {


### PR DESCRIPTION
This PR is responsible for loading tasks in subdirectories relative to the `app/Tasks` directory.

It fixes #28.